### PR TITLE
fix(deps): resolve openssl-sys version conflict

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1153,9 +1153,9 @@ dependencies = [
 
 [[package]]
 name = "native-tls"
-version = "0.2.14"
+version = "0.2.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87de3442987e9dbec73158d5c715e7ad9072fda936bb03d19d7fa10e00520f0e"
+checksum = "465500e14ea162429d264d44189adc38b199b62b1c21eea9f69e4b73cb03bbf2"
 dependencies = [
  "libc",
  "log",
@@ -1259,9 +1259,9 @@ dependencies = [
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.113"
+version = "0.9.114"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad2f2c0eba47118757e4c6d2bff2838f3e0523380021356e7875e858372ce644"
+checksum = "13ce1245cd07fcc4cfdb438f7507b0c7e4f3849a69fd84d52374c66d83741bb6"
 dependencies = [
  "cc",
  "libc",


### PR DESCRIPTION
## Summary

- Update `native-tls` from 0.2.14 to 0.2.18
- Update `openssl-sys` from 0.9.113 to 0.9.114

This resolves a cargo version conflict where:
- `native-tls 0.2.18` requires `openssl-sys ^0.9.111`  
- `openssl 0.10.77` requires `openssl-sys ^0.9.113`

Both can now resolve to openssl-sys 0.9.114.

## CI Status

CI run on original PR failed due to this conflict - this PR fixes that.

🤖 Generated with [Claude Code](https://claude.ai/code)
via [Happy](https://happy.engineering)