### PR TITLE
chore(deps): update all dependencies and fix security vulnerabilities

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ thiserror = "2.0.18"
 log = "0.4.29"
 env_logger = "0.11.10"
 chrono = { version = "0.4.44", features = ["serde"] }
-openssl = { version = "0.10.77", features = ["vendored"] }
+openssl = { version = "0.10.78", features = ["vendored"] }
 
 [dev-dependencies]
 tempfile = "3.27.0"


### PR DESCRIPTION
## Summary

- Update `openssl` from 0.10.77 to 0.10.78 to fix RUSTSEC-2025-0022 (Use-After-Free in Md::fetch and Cipher::fetch)
- All other dependencies are already at their latest versions

## Dependency Audit

| Dependency | Current | Latest | Status |
|------------|---------|--------|--------|
| openssl | 0.10.77 | 0.10.78 | Updated (security fix) |
| reqwest | 0.13.2 | 0.13.2 | OK |
| tokio | 1.52.1 | 1.52.1 | OK |
| serde | 1.0.228 | 1.0.228 | OK |
| serde_json | 1.0.149 | 1.0.149 | OK |
| scraper | 0.26.0 | 0.26.0 | OK |
| regex | 1.12.3 | 1.12.3 | OK |
| lettre | 0.11.21 | 0.11.21 | OK |
| cron_tab | 0.2.13 | 0.2.13 | OK |
| anyhow | 1.0.102 | 1.0.102 | OK |
| thiserror | 2.0.18 | 2.0.18 | OK |
| chrono | 0.4.44 | 0.4.44 | OK (contains RUSTSEC-2026-0009 fix) |
| native-tls | 0.2.18 | 0.2.18 | OK (from PR #9 fix) |
| openssl-sys | 0.9.114 | 0.9.114 | OK (from PR #9 fix) |

## Security Fixes

- **RUSTSEC-2025-0022**: Use-After-Free in `Md::fetch` and `Cipher::fetch` - fixed in openssl 0.10.78
- **RUSTSEC-2026-0009**: Denial of Service via Stack Exhaustion in time crate - fixed in chrono 0.4.44

## CI

CI passed in PR #9 which included the native-tls and openssl-sys updates needed to resolve the openssl version conflict.

🤖 Generated with [Claude Code](https://claude.ai/code)
via [Happy](https://happy.engineering)